### PR TITLE
Use correct type "WatchQueryOptions" on query options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ module.exports = {
 
     const operationImport = `${
       operations.some((op) => op.operation == "query")
-        ? "ApolloQueryResult, ObservableQuery, QueryOptions, "
+        ? "ApolloQueryResult, ObservableQuery, WatchQueryOptions, "
         : ""
     }${
       operations.some((op) => op.operation == "mutation")
@@ -84,7 +84,7 @@ module.exports = {
         if (o.operation == "query") {
           operation = `export const ${o.name.value} = (
             options: Omit<
-              QueryOptions<${opv}>, 
+              WatchQueryOptions<${opv}>, 
               "query"
             >
           ): Readable<


### PR DESCRIPTION
Fixes https://github.com/ticruz38/graphql-codegen-svelte-apollo/issues/12

Since the "query" operation utilizes `client.watchQuery`, we should be using the `WatchQueryOptions` type on options vs `QueryOptions`