### PR TITLE
Add pascal casing to operation names for async queries.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ module.exports = {
                 if (config.asyncQuery) {
                     operation =
                         operation +
-                            ("\n              export const Async" + o.name.value + " = (\n                options: Omit<\n                  QueryOptions<" + opv + ">,\n                  \"query\"\n                >\n              ) => {\n                return client.query<" + op + ">({query: " + pascal_case_1.pascalCase(o.name.value) + "Doc, ...options})\n              }\n            ");
+                            ("\n              export const Async" + pascal_case_1.pascalCase(o.name.value) + " = (\n                options: Omit<\n                  QueryOptions<" + opv + ">,\n                  \"query\"\n                >\n              ) => {\n                return client.query<" + op + ">({query: " + pascal_case_1.pascalCase(o.name.value) + "Doc, ...options})\n              }\n            ");
                 }
             }
             if (o.operation == "mutation") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ module.exports = {
             operation =
               operation +
               `
-              export const Async${o.name.value} = (
+              export const Async${pascalCase(o.name.value)} = (
                 options: Omit<
                   QueryOptions<${opv}>,
                   "query"


### PR DESCRIPTION
We are having an issue in our project using this plugin where our query definitions are in camelCase instead of PascalCase (not standard I know). Maybe this change would fix the issue.