### PR TITLE
Exit 1 if config.clientPath is not set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql-codegen-svelte-apollo",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql-codegen-svelte-apollo",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.2.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,7 @@ module.exports = {
   validate: (schema, documents, config, outputFile, allPlugins) => {
     if (!config.clientPath) {
       console.warn("Client path is not present in config");
+      process.exit(1);
     }
   },
 } as CodegenPlugin;


### PR DESCRIPTION
First, thank you for making such a nice library 🎉 .

I found that a success message was shown even if `config.clientPath` was not set.

<img width="835" alt="image" src="https://user-images.githubusercontent.com/40315079/156955301-4f86665d-7e8b-4aed-9bd2-22cbe893c18e.png">
I think many users will miss the warning message   (`Client path is not present in config`) 😢.

In this PR, I added `process.exit(1)` to show the warning clearly.
The following is a screenshot of this PR.

<img width="835" alt="image" src="https://user-images.githubusercontent.com/40315079/156955616-1177bcd9-e02b-40cf-813c-bc601af4bf83.png">


